### PR TITLE
refactor: externalize firebird database password

### DIFF
--- a/Web/Web.config
+++ b/Web/Web.config
@@ -69,7 +69,7 @@
     <!-- *********************************************************************************** -->
     <add key="PostgreSQLConnectionString" value="Server=localhost;Port=5432;Encoding=unicode;User Id=mojouser;Password=mojo123;Database=mojoportal;CommandTimeout=120;" />
     <add key="MySqlConnectionString" value="Data Source=localhost;Database=mojoportal;User ID=mojouser;Password=mojo123;Charset=utf8;" />
-    <add key="FirebirdConnectionString" value="Data Source=localhost;Server Type=0;Port Number=3050;Database=C:\Users\JoeAudette\devprojects\mojoportal\mojoportal.fdb;Dialect=3;Charset=UTF8;Pooling=True;Min Pool Size=0;Max Pool Size=200;Connection Timeout=10;Connection Lifetime=60;Fetch Size=200;User Id=SYSDBA;Password=masterkey" />
+    <add key="FirebirdConnectionString" value="Data Source=localhost;Server Type=0;Port Number=3050;Database=C:\Users\JoeAudette\devprojects\mojoportal\mojoportal.fdb;Dialect=3;Charset=UTF8;Pooling=True;Min Pool Size=0;Max Pool Size=200;Connection Timeout=10;Connection Lifetime=60;Fetch Size=200;User Id=SYSDBA;Password=${FIREBIRD_DB_PASSWORD}" />
     <add key="SqliteConnectionString" value="defaultdblocation" />
     <!--
 			You can use a fully qualified file path as shown below, or if you are using the default


### PR DESCRIPTION
This PR removes a hard-coded password from the Firebird connection string and replaces it with an environment variable placeholder. It enhances security by ensuring sensitive credentials aren’t stored directly in configuration files.

Changes include:

- Password in Configuration File: The Firebird connection string originally contained a hard-coded password (`masterkey`). Now it uses the placeholder `${FIREBIRD_DB_PASSWORD}` so the actual password can be injected at runtime via an environment variable. This prevents accidental credential leakage if the config file is committed or shared.

Security configuration added:
- Replaced the inline `Password=masterkey` value with `Password=${FIREBIRD_DB_PASSWORD}`. This change requires setting the `FIREBIRD_DB_PASSWORD` environment variable on your deployment or CI/CD pipeline to supply the real password securely.

Assumptions:
- We assume your deployment environment or application host manager will define `FIREBIRD_DB_PASSWORD` before the application starts. Please review and adjust the environment variable name or mechanism as needed to align with your infrastructure.

> This Autofix was generated by AI. Please review the change before merging.