### PR TITLE
refactor: replace RijndaelManaged with Aes

### DIFF
--- a/mojoPortal.Web.Framework/Crypto/CryptoHelper.cs
+++ b/mojoPortal.Web.Framework/Crypto/CryptoHelper.cs
@@ -176,17 +176,19 @@ namespace mojoPortal.Web.Framework
         {
             if (value == string.Empty) return string.Empty;
 
-            RijndaelManaged crypto = new RijndaelManaged();
-            MemoryStream memoryStream = new MemoryStream(Convert.FromBase64String(value));
+            using (Aes crypto = Aes.Create())
+            {
+                MemoryStream memoryStream = new MemoryStream(Convert.FromBase64String(value));
 
-            CryptoStream cryptoStream = new CryptoStream(
-                memoryStream, 
-                crypto.CreateDecryptor(key_192, iv_128),
-                CryptoStreamMode.Read);
+                CryptoStream cryptoStream = new CryptoStream(
+                    memoryStream, 
+                    crypto.CreateDecryptor(key_192, iv_128),
+                    CryptoStreamMode.Read);
 
-            StreamReader streamReader = new StreamReader(cryptoStream);
+                StreamReader streamReader = new StreamReader(cryptoStream);
 
-            return streamReader.ReadToEnd();
+                return streamReader.ReadToEnd();
+            }
         }
 
         public static string SignAndSecureData(string value)


### PR DESCRIPTION
This PR updates the decryption routine to use the modern Aes implementation instead of the legacy RijndaelManaged class. It also ensures proper disposal of cryptographic resources by wrapping the Aes object in a using statement.

- Use Of Broken Or Risky Cryptographic Algorithm: The original code relied on RijndaelManaged, which is now considered a risky and deprecated API. We switched to Aes.Create() to leverage the standardized AES algorithm and wrapped it in a using block so that the crypto object is disposed securely after use. We assumed that the existing 192-bit key and 128-bit IV sizes are correct for AES; please review these values to confirm they meet your security requirements.

> This Autofix was generated by AI. Please review the change before merging.