### PR TITLE
refactor: enable request validation

### DIFF
--- a/Web/Web.config
+++ b/Web/Web.config
@@ -762,31 +762,31 @@
 				es-ES Spanish Spain
 				es-MX Spanish Mexico
 				el-GR Greek Greece
-				da-DK Danish Denmark
-				de-DE German Germany
-				fi-FI Finnish Finland
-				fr-FR French France
-				fr-CA French Canada
-				he-IL Hebrew Israel             - need to fix the datepicker .js file
-				it-IT Italian Italy
-				ko-KR Korean Korea              - need to fix the datepicker .js file
-				nl-NL Dutch Netherlands
-				nl-BG Dutch Belgium
-				pt-BR Portuguese Brazil
-				pl-PL Polish Poland
-				sv-SE Swedish Sweden
-				sv-FI Swedish Finland
-				ru-RU Russian Russia
-				tr-TR Turkish Turkey
+					da-DK Danish Denmark
+					de-DE German Germany
+					fi-FI Finnish Finland
+					fr-FR French France
+					fr-CA French Canada
+					he-IL Hebrew Israel             - need to fix the datepicker .js file
+					it-IT Italian Italy
+					ko-KR Korean Korea              - need to fix the datepicker .js file
+					nl-NL Dutch Netherlands
+					nl-BG Dutch Belgium
+					pt-BR Portuguese Brazil
+					pl-PL Polish Poland
+					sv-SE Swedish Sweden
+					sv-FI Swedish Finland
+					ru-RU Russian Russia
+					tr-TR Turkish Turkey
 
-				more complete list here: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
+					more complete list here: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
 
-				auto:en-US causes ASP.NET to try and find resources for the prefered language in the
-				browser settings with fallback to the default culture, en-US. In this example,
-				the default culture must not have any missing keys in the resource files. en-US is
-				the only language with no missing keys in the resource files, so you should
-				leave the default as en-US.
-			-->
+					auto:en-US causes ASP.NET to try and find resources for the prefered language in the
+					browser settings with fallback to the default culture, en-US. In this example,
+					the default culture must not have any missing keys in the resource files. en-US is
+					the only language with no missing keys in the resource files, so you should
+					leave the default as en-US.
+				-->
       <globalization culture="auto:en-US" uiCulture="auto:en-US" requestEncoding="utf-8" responseEncoding="utf-8" fileEncoding="iso-8859-15" />
       <siteMap configSource="mojoSiteMap.config" />
       <webParts>
@@ -812,7 +812,7 @@
           <add name="mojoRoleProvider" type="mojoPortal.Web.mojoRoleProvider" />
         </providers>
       </roleManager>
-      <pages validateRequest="false" viewStateEncryptionMode="Auto" maxPageStateFieldLength="500" controlRenderingCompatibilityVersion="4.5" clientIDMode="AutoID">
+      <pages validateRequest="true" viewStateEncryptionMode="Auto" maxPageStateFieldLength="500" controlRenderingCompatibilityVersion="4.5" clientIDMode="AutoID">
         <namespaces>
           <add namespace="System.Globalization" />
           <add namespace="System.Web.Mvc" />


### PR DESCRIPTION
This PR enables ASP.NET request validation to protect against XSS attacks and tidies the indentation of locale entries for better readability.

- No Request Validation: Previously, the `<pages>` element had `validateRequest="false"`, which allowed HTML or script in user input to bypass ASP.NET’s built-in checks. We changed it to `validateRequest="true"` so that dangerous payloads are automatically blocked at the framework level, reducing the risk of cross-site scripting.

Security Configuration Added:
- Added `validateRequest="true"` to the `<pages>` configuration in Web.config. This flag tells ASP.NET to inspect incoming requests and reject those containing potentially dangerous content (e.g., HTML tags, script blocks).
- Assumption: Enabling global request validation may impact any existing handlers that legitimately require raw HTML input. Please review any pages that currently rely on disabled validation and consider using the `[ValidateInput(false)]` attribute on a per-page basis if needed.

> This Autofix was generated by AI. Please review the change before merging.