### PR TITLE
refactor: replace risky RijndaelManaged with Aes

### DIFF
--- a/mojoPortal.Web.Framework/Crypto/CryptoHelper.cs
+++ b/mojoPortal.Web.Framework/Crypto/CryptoHelper.cs
@@ -176,17 +176,21 @@ namespace mojoPortal.Web.Framework
         {
             if (value == string.Empty) return string.Empty;
 
-            RijndaelManaged crypto = new RijndaelManaged();
-            MemoryStream memoryStream = new MemoryStream(Convert.FromBase64String(value));
+            using (Aes aes = Aes.Create())
+            {
+                aes.Key = key_192;
+                aes.IV = iv_128;
 
-            CryptoStream cryptoStream = new CryptoStream(
-                memoryStream, 
-                crypto.CreateDecryptor(key_192, iv_128),
-                CryptoStreamMode.Read);
-
-            StreamReader streamReader = new StreamReader(cryptoStream);
-
-            return streamReader.ReadToEnd();
+                using (MemoryStream memoryStream = new MemoryStream(Convert.FromBase64String(value)))
+                using (CryptoStream cryptoStream = new CryptoStream(
+                    memoryStream,
+                    aes.CreateDecryptor(),
+                    CryptoStreamMode.Read))
+                using (StreamReader streamReader = new StreamReader(cryptoStream))
+                {
+                    return streamReader.ReadToEnd();
+                }
+            }
         }
 
         public static string SignAndSecureData(string value)


### PR DESCRIPTION
This PR replaces the use of the legacy RijndaelManaged class with the standard Aes implementation and ensures that all cryptographic objects are properly disposed. The changes improve security by using AES with secure defaults and eliminating a potentially broken or risky algorithm.

- Use Of Broken Or Risky Cryptographic Algorithm
  The code originally instantiated a RijndaelManaged cipher, which supports nonstandard block sizes and may not receive the same level of security scrutiny as the AES class. We now call Aes.Create(), assign the existing key and IV, and wrap streams in using statements to ensure proper disposal. This guarantees use of AES with a 128-bit block size, default CBC mode, and PKCS7 padding, removing reliance on a weaker or poorly supported algorithm.

No explicit security configuration values were added beyond leveraging Aes.Create() defaults. We assume the provided key (192-bit) and IV (128-bit) lengths are correct; please review these values and update if a different key size or authenticated encryption mode (e.g., GCM) is required.

> This Autofix was generated by AI. Please review the change before merging.