### PR TITLE
refactor: sanitize rendered content to mitigate stored xss

### DIFF
--- a/Web/Services/TinyMceTemplates.ashx.cs
+++ b/Web/Services/TinyMceTemplates.ashx.cs
@@ -134,7 +134,16 @@ namespace mojoPortal.Web.Services
 				}
 			}
 
-			context.Response.Write(JsonConvert.SerializeObject(new TinyMceTemplateCollection(collection).Templates));
+            var templates = new TinyMceTemplateCollection(collection).Templates;
+            foreach (var t in templates)
+            {
+                t.Title = HttpUtility.HtmlEncode(t.Title);
+                t.Image = HttpUtility.HtmlEncode(t.Image);
+                t.Description = HttpUtility.HtmlEncode(t.Description);
+                t.Html = HttpUtility.HtmlEncode(t.Html);
+            }
+
+            context.Response.Write(JsonConvert.SerializeObject(templates));
             
         }
 

--- a/mojoPortal.Features.UI/EventCalendar/EventDetails.aspx.cs
+++ b/mojoPortal.Features.UI/EventCalendar/EventDetails.aspx.cs
@@ -62,11 +62,11 @@ namespace mojoPortal.Web.EventCalendarUI
                     return;
                 }
 
-                heading.Text = calendarEvent.Title + " - " + calendarEvent.EventDate.ToShortDateString();
+                heading.Text = System.Web.HttpUtility.HtmlEncode(calendarEvent.Title) + " - " + calendarEvent.EventDate.ToShortDateString();
 
-                Title = SiteUtils.FormatPageTitle(siteSettings, calendarEvent.Title);
+                Title = SiteUtils.FormatPageTitle(siteSettings, System.Web.HttpUtility.HtmlEncode(calendarEvent.Title));
 
-                this.litDescription.Text = calendarEvent.Description;
+                this.litDescription.Text = System.Web.HttpUtility.HtmlEncode(calendarEvent.Description);
                 this.lblStartTime.Text = calendarEvent.StartTime.ToShortTimeString();
                 this.lblEndTime.Text = calendarEvent.EndTime.ToShortTimeString();
 
@@ -90,8 +90,8 @@ namespace mojoPortal.Web.EventCalendarUI
                 {
                     gmap.Visible = false;
                 }
-				lblLocation.Text = calendarEvent.Location;
-				pnlOuterWrap.SetOrAppendCss(config.InstanceCssClass);
+                lblLocation.Text = System.Web.HttpUtility.HtmlEncode(calendarEvent.Location);
+                pnlOuterWrap.SetOrAppendCss(config.InstanceCssClass);
             }
         }
 

--- a/mojoPortal.Features.UI/Forums/Controls/PostList.ascx
+++ b/mojoPortal.Features.UI/Forums/Controls/PostList.ascx
@@ -15,7 +15,7 @@
 	<asp:HyperLink ID="lnkLogin" runat="server" CssClass="ModulePager" SkinID="ForumLoginLink" />
 </portal:FormGroupPanel>
 
-<div class='postlistwrap <%= displaySettings.PostListCssClass %>'>
+<div class='postlistwrap <%= Server.HtmlEncode(displaySettings.PostListCssClass) %>'>
 	<asp:Repeater ID="rptMessages" runat="server" EnableViewState="False">
 		<ItemTemplate>
 			<div class="postcontainer" id='post<%# DataBinder.Eval(Container.DataItem,"PostID") %>'>
@@ -108,150 +108,150 @@
 									NavigateUrl='<%# FormatEditUrl(Convert.ToInt32(Eval("ForumID")),Convert.ToInt32(Eval("ThreadID")), Convert.ToInt32(Eval("PostID")))  %>'
 									Visible='<%# GetPermission(Convert.ToInt32(Eval("UserID")), Convert.ToBoolean(Eval("IsLocked")), Convert.ToDateTime(Eval("PostDate"))) %>' />
 								<%# Server.HtmlEncode(Eval("Subject").ToString())%>
-							</h3>
-						</div>
+                        </h3>
+                    </div>
 
-						<div class="postbody" id="divUntrustedPost" runat="server" visible='<%# !(Convert.ToBoolean(Eval("Trusted")) || filterContentFromTrustedUsers) %>'>
-							<NeatHtml:UntrustedContent ID="UntrustedContent1" runat="server" TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
-								ClientScriptUrl="~/ClientScript/NeatHtml.js">
-								<%# Eval("Post").ToString()%>
-							</NeatHtml:UntrustedContent>
-						</div>
+                    <div class="postbody" id="divUntrustedPost" runat="server" visible='<%# !(Convert.ToBoolean(Eval("Trusted")) || filterContentFromTrustedUsers) %>'>
+                        <NeatHtml:UntrustedContent ID="UntrustedContent1" runat="server" TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
+                            ClientScriptUrl="~/ClientScript/NeatHtml.js">
+                            <%# System.Web.HttpUtility.HtmlEncode(Eval("Post").ToString()) %>
+                        </NeatHtml:UntrustedContent>
+                    </div>
 
-						<div class="postbody" id="divTrustedPost" runat="server" visible='<%# (Convert.ToBoolean(Eval("Trusted")) && !filterContentFromTrustedUsers) %>'>
-							<%# Eval("Post").ToString()%>
-						</div>
-					</div>
-				</div>
-			</div>
-		</ItemTemplate>
+                    <div class="postbody" id="divTrustedPost" runat="server" visible='<%# (Convert.ToBoolean(Eval("Trusted")) && !filterContentFromTrustedUsers) %>'>
+                        <%# System.Web.HttpUtility.HtmlEncode(Eval("Post").ToString()) %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </ItemTemplate>
 
-		<AlternatingItemTemplate>
-			<div class="postcontainer postcontaineralt" id='post<%# DataBinder.Eval(Container.DataItem,"PostID") %>'>
-				<div class="forumpostheader">
-					<%# FormatDate(Convert.ToDateTime(Eval("PostDate")))%>
-					<div data-tb='<%# Eval("PostID") %>' runat="server" visible='<%# IsModerator && !Convert.ToBoolean(Eval("NotificationSent")) %>' class="cmdbar">
-						<a runat="server"
-							id="lnkSendNotification"
-							href="#" class="forumcommand sendnotification"
-							data-post='<%# Eval("PostID") %>'
-							data-cmd="sendnotification">
-							<%# Resources.ForumResources.SendNotification %>
-						</a>
-						<a runat="server"
-							id="lnkMarkAsSent"
-							href="#"
-							class="forumcommand marksent"
-							data-post='<%# Eval("PostID") %>'
-							data-cmd="marksent">
-							<%# Resources.ForumResources.MarkAsSent %>
-						</a>
-					</div>
-				</div>
+    <AlternatingItemTemplate>
+        <div class="postcontainer postcontaineralt" id='post<%# DataBinder.Eval(Container.DataItem,"PostID") %>'>
+            <div class="forumpostheader">
+                <%# FormatDate(Convert.ToDateTime(Eval("PostDate")))%>
+                <div data-tb='<%# Eval("PostID") %>' runat="server" visible='<%# IsModerator && !Convert.ToBoolean(Eval("NotificationSent")) %>' class="cmdbar">
+                    <a runat="server"
+                        id="lnkSendNotification"
+                        href="#" class="forumcommand sendnotification"
+                        data-post='<%# Eval("PostID") %>'
+                        data-cmd="sendnotification">
+                        <%# Resources.ForumResources.SendNotification %>
+                    </a>
+                    <a runat="server"
+                        id="lnkMarkAsSent"
+                        href="#"
+                        class="forumcommand marksent"
+                        data-post='<%# Eval("PostID") %>'
+                        data-cmd="marksent">
+                        <%# Resources.ForumResources.MarkAsSent %>
+                    </a>
+                </div>
+            </div>
 
-				<div class="postwrapper">
-					<div class="postleft">
-						<div class="forumpostusername">
-							<asp:HyperLink runat="server"
-								Text="Edit"
-								ID="Hyperlink2"
-								ImageUrl='<%# ImageSiteRoot + "/Data/SiteImages/user_edit.png"  %>'
-								NavigateUrl='<%# SiteRoot + "/Admin/ManageUsers.aspx?userid=" + DataBinder.Eval(Container.DataItem,"UserID")   %>'
-								Visible="<%# IsAdmin %>" />
-							<%# GetProfileLinkOrLabel(Convert.ToInt32(Eval("UserID")), Eval("PostAuthor").ToString())%>
-						</div>
+            <div class="postwrapper">
+                <div class="postleft">
+                    <div class="forumpostusername">
+                        <asp:HyperLink runat="server"
+                            Text="Edit"
+                            ID="Hyperlink2"
+                            ImageUrl='<%# ImageSiteRoot + "/Data/SiteImages/user_edit.png"  %>'
+                            NavigateUrl='<%# SiteRoot + "/Admin/ManageUsers.aspx?userid=" + DataBinder.Eval(Container.DataItem,"UserID")   %>'
+                            Visible="<%# IsAdmin %>" />
+                        <%# GetProfileLinkOrLabel(Convert.ToInt32(Eval("UserID")), Eval("PostAuthor").ToString())%>
+                    </div>
 
-						<div class="forumpostuseravatar">
-							<portal:Avatar ID="av1" runat="server"
-								UseLink='<%# UseProfileLink() %>'
-								MaxAllowedRating='<%# MaxAllowedGravatarRating %>'
-								AvatarFile='<%# Eval("PostAuthorAvatar") %>'
-								UserName='<%# Eval("PostAuthor") %>'
-								UserId='<%# Convert.ToInt32(Eval("UserID")) %>'
-								SiteId='<%# SiteSettings.SiteId %>'
-								SiteRoot='<%# SiteRoot %>'
-								Email='<%# Eval("AuthorEmail") %>'
-								UserNameTooltipFormat='<%# UserNameTooltipFormat %>'
-								Disable='<%# disableAvatars %>'
-								UseGravatar='<%# allowGravatars %>'
-								GravatarFallbackEmailAddress="noreply@noreply.com" />
-						</div>
+                    <div class="forumpostuseravatar">
+                        <portal:Avatar ID="av1" runat="server"
+                            UseLink='<%# UseProfileLink() %>'
+                            MaxAllowedRating='<%# MaxAllowedGravatarRating %>'
+                            AvatarFile='<%# Eval("PostAuthorAvatar") %>'
+                            UserName='<%# Eval("PostAuthor") %>'
+                            UserId='<%# Convert.ToInt32(Eval("UserID")) %>'
+                            SiteId='<%# SiteSettings.SiteId %>'
+                            SiteRoot='<%# SiteRoot %>'
+                            Email='<%# Eval("AuthorEmail") %>'
+                            UserNameTooltipFormat='<%# UserNameTooltipFormat %>'
+                            Disable='<%# disableAvatars %>'
+                            UseGravatar='<%# allowGravatars %>'
+                            GravatarFallbackEmailAddress="noreply@noreply.com" />
+                    </div>
 
-						<div class="forumpostuserattribute">
-							<mp:SiteLabel runat="server"
-								ID="lblTotalPosts"
-								ConfigKey="ManageUsersTotalPostsLabel"
-								UseLabelTag="false" />
-							<%# Eval("PostAuthorTotalPosts") %>
-						</div>
+                    <div class="forumpostuserattribute">
+                        <mp:SiteLabel runat="server"
+                            ID="lblTotalPosts"
+                            ConfigKey="ManageUsersTotalPostsLabel"
+                            UseLabelTag="false" />
+                        <%# Eval("PostAuthorTotalPosts") %>
+                    </div>
 
-						<div class="forumpostuserattribute">
-							<portal:ForumUserThreadLink runat="server"
-								ID="lnkUserPosts"
-								UserId='<%# Convert.ToInt32(DataBinder.Eval(Container.DataItem,"UserID")) %>'
-								TotalPosts='<%# Convert.ToInt32(Eval("PostAuthorTotalPosts")) %>' />
-						</div>
+                    <div class="forumpostuserattribute">
+                        <portal:ForumUserThreadLink runat="server"
+                            ID="lnkUserPosts"
+                            UserId='<%# Convert.ToInt32(DataBinder.Eval(Container.DataItem,"UserID")) %>'
+                            TotalPosts='<%# Convert.ToInt32(Eval("PostAuthorTotalPosts")) %>' />
+                    </div>
 
-						<div id="divRevenue" runat="server" visible='<%# showUserRevenue %>' class="forumpostuserattribute">
-							<mp:SiteLabel runat="server"
-								ID="SiteLabel1"
-								ConfigKey="UserSalesLabel"
-								ResourceFile="ForumResources"
-								UseLabelTag="false" />
-							<%# string.Format(currencyCulture, "{0:c}", Convert.ToDecimal(Eval("UserRevenue"))) %>
-						</div>
+                    <div id="divRevenue" runat="server" visible='<%# showUserRevenue %>' class="forumpostuserattribute">
+                        <mp:SiteLabel runat="server"
+                            ID="SiteLabel1"
+                            ConfigKey="UserSalesLabel"
+                            ResourceFile="ForumResources"
+                            UseLabelTag="false" />
+                        <%# string.Format(currencyCulture, "{0:c}", Convert.ToDecimal(Eval("UserRevenue"))) %>
+                    </div>
 
-						<div class="forumpostuserattribute" id="divUntrustedSignature" runat="server" visible='<%# !Convert.ToBoolean(Eval("Trusted")) %>'>
-							<NeatHtml:UntrustedContent runat="server"
-								ID="UntrustedContent2"
-								TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
-								ClientScriptUrl="~/ClientScript/NeatHtml.js">
-								<%# Eval("PostAuthorSignature").ToString()%>
-							</NeatHtml:UntrustedContent>
-						</div>
+                    <div class="forumpostuserattribute" id="divUntrustedSignature" runat="server" visible='<%# !Convert.ToBoolean(Eval("Trusted")) %>'>
+                        <NeatHtml:UntrustedContent runat="server"
+                            ID="UntrustedContent2"
+                            TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
+                            ClientScriptUrl="~/ClientScript/NeatHtml.js">
+                            <%# System.Web.HttpUtility.HtmlEncode(Eval("PostAuthorSignature").ToString()) %>
+                        </NeatHtml:UntrustedContent>
+                    </div>
 
-						<div class="forumpostuserattribute" id="divTrustedSignature" runat="server" visible='<%# Convert.ToBoolean(Eval("Trusted")) %>'>
-							<NeatHtml:UntrustedContent runat="server"
-								ID="UntrustedContent3"
-								TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
-								ClientScriptUrl="~/ClientScript/NeatHtml.js">
-								<%# Eval("PostAuthorSignature").ToString()%>
-							</NeatHtml:UntrustedContent>
-						</div>
-					</div>
+                    <div class="forumpostuserattribute" id="divTrustedSignature" runat="server" visible='<%# Convert.ToBoolean(Eval("Trusted")) %>'>
+                        <NeatHtml:UntrustedContent runat="server"
+                            ID="UntrustedContent3"
+                            TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
+                            ClientScriptUrl="~/ClientScript/NeatHtml.js">
+                            <%# System.Web.HttpUtility.HtmlEncode(Eval("PostAuthorSignature").ToString()) %>
+                        </NeatHtml:UntrustedContent>
+                    </div>
+                </div>
 
-					<div class="postright">
-						<div class="posttopic">
-							<h3>
-								<asp:HyperLink runat="server"
-									CssClass="postEdit"
-									ToolTip="<%# Resources.ForumResources.ForumEditPostLink %>"
-									ID="editLink"
-									NavigateUrl='<%# FormatEditUrl(Convert.ToInt32(Eval("ForumID")),Convert.ToInt32(Eval("ThreadID")), Convert.ToInt32(Eval("PostID")))  %>'
-									Visible='<%# GetPermission(Convert.ToInt32(Eval("UserID")), Convert.ToBoolean(Eval("IsLocked")), Convert.ToDateTime(Eval("PostDate"))) %>' />
-								<%# Server.HtmlEncode(Eval("Subject").ToString())%>
-							</h3>
-						</div>
+                <div class="postright">
+                    <div class="posttopic">
+                        <h3>
+                            <asp:HyperLink runat="server"
+                                CssClass="postEdit"
+                                ToolTip="<%# Resources.ForumResources.ForumEditPostLink %>"
+                                ID="editLink"
+                                NavigateUrl='<%# FormatEditUrl(Convert.ToInt32(Eval("ForumID")),Convert.ToInt32(Eval("ThreadID")), Convert.ToInt32(Eval("PostID")))  %>'
+                                Visible='<%# GetPermission(Convert.ToInt32(Eval("UserID")), Convert.ToBoolean(Eval("IsLocked")), Convert.ToDateTime(Eval("PostDate"))) %>' />
+                            <%# Server.HtmlEncode(Eval("Subject").ToString())%>
+                        </h3>
+                    </div>
 
-						<div class="postbody" id="divUntrustedPost" runat="server" visible='<%# !(Convert.ToBoolean(Eval("Trusted")) || filterContentFromTrustedUsers) %>'>
-							<NeatHtml:UntrustedContent ID="UntrustedContent1" runat="server" TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
-								ClientScriptUrl="~/ClientScript/NeatHtml.js">
-								<%# Eval("Post").ToString()%>
-							</NeatHtml:UntrustedContent>
-						</div>
-						<div class="postbody" id="divTrustedPost" runat="server" visible='<%# (Convert.ToBoolean(Eval("Trusted")) && !filterContentFromTrustedUsers) %>'>
-							<%# Eval("Post").ToString()%>
-						</div>
-					</div>
-				</div>
-			</div>
-		</AlternatingItemTemplate>
-	</asp:Repeater>
+                    <div class="postbody" id="divUntrustedPost" runat="server" visible='<%# !(Convert.ToBoolean(Eval("Trusted")) || filterContentFromTrustedUsers) %>'>
+                        <NeatHtml:UntrustedContent ID="UntrustedContent1" runat="server" TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
+                            ClientScriptUrl="~/ClientScript/NeatHtml.js">
+                            <%# System.Web.HttpUtility.HtmlEncode(Eval("Post").ToString()) %>
+                        </NeatHtml:UntrustedContent>
+                    </div>
+                    <div class="postbody" id="divTrustedPost" runat="server" visible='<%# (Convert.ToBoolean(Eval("Trusted")) && !filterContentFromTrustedUsers) %>'>
+                        <%# System.Web.HttpUtility.HtmlEncode(Eval("Post").ToString()) %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AlternatingItemTemplate>
+</asp:Repeater>
 </div>
 
 <portal:FormGroupPanel runat="server" CssClass="modulepager">
-	<portal:mojoCutePager ID="pgrBottom" runat="server" />
-	<asp:HyperLink runat="server" ID="lnkNewPostBottom" Visible="false" SkinID="ForumNewPostBottom" />
-	<asp:HyperLink ID="lnkLoginBottom" runat="server" CssClass="ModulePager" SkinID="ForumLoginLink" />
-	<portal:mojoLabel ID="lblClosedBottom" runat="server" CssClass="closedthreadmessage" Visible="false" EnableViewState="false" SkinID="ForumClosedMessage" />
+    <portal:mojoCutePager ID="pgrBottom" runat="server" />
+    <asp:HyperLink runat="server" ID="lnkNewPostBottom" Visible="false" SkinID="ForumNewPostBottom" />
+    <asp:HyperLink ID="lnkLoginBottom" runat="server" CssClass="ModulePager" SkinID="ForumLoginLink" />
+    <portal:mojoLabel ID="lblClosedBottom" runat="server" CssClass="closedthreadmessage" Visible="false" EnableViewState="false" SkinID="ForumClosedMessage" />
 </portal:FormGroupPanel>

--- a/mojoPortal.Features.UI/Forums/Controls/PostListAlt.ascx
+++ b/mojoPortal.Features.UI/Forums/Controls/PostListAlt.ascx
@@ -25,11 +25,11 @@
                     <div class="postbody" id="divUntrustedPost" runat="server" visible='<%# !(Convert.ToBoolean(Eval("Trusted")) || filterContentFromTrustedUsers) %>'>
                         <NeatHtml:UntrustedContent ID="UntrustedContent1" runat="server" TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
                             ClientScriptUrl="~/ClientScript/NeatHtml.js">
-                            <%# Eval("Post").ToString()%>
+                            <%# Server.HtmlEncode(Eval("Post").ToString())%>
                         </NeatHtml:UntrustedContent>
                     </div>
                     <div class="postbody" id="divTrustedPost" runat="server" visible='<%# (Convert.ToBoolean(Eval("Trusted")) && !filterContentFromTrustedUsers) %>'>
-                            <%# Eval("Post").ToString()%>
+                            <%# Server.HtmlEncode(Eval("Post").ToString())%>
                     </div>
                 </div>
                 <div class="postuser">
@@ -54,17 +54,17 @@
                         <tr>
                             <td id="tdAvatars" runat="server" visible='<%# !displaySettings.HideAvatars %>'>
                                  <portal:Avatar id="av1" runat="server"
-	                                UseLink='<%# UseProfileLink() %>'
-	                                MaxAllowedRating='<%# MaxAllowedGravatarRating %>'
+                                        UseLink='<%# UseProfileLink() %>'
+                                        MaxAllowedRating='<%# MaxAllowedGravatarRating %>'
                                     AvatarFile='<%# Eval("PostAuthorAvatar") %>'
-	                                UserName='<%# Eval("PostAuthor") %>'
+                                        UserName='<%# Eval("PostAuthor") %>'
                                     UserId='<%# Convert.ToInt32(Eval("UserID")) %>'
                                     SiteId='<%# SiteSettings.SiteId %>'
                                     SiteRoot='<%# SiteRoot %>'
-	                                Email='<%# Eval("AuthorEmail") %>'
+                                        Email='<%# Eval("AuthorEmail") %>'
                                     UserNameTooltipFormat='<%# UserNameTooltipFormat %>'
-	                                Disable='<%# disableAvatars %>'
-	                                UseGravatar='<%# allowGravatars %>'
+                                        Disable='<%# disableAvatars %>'
+                                        UseGravatar='<%# allowGravatars %>'
                                     GravatarFallbackEmailAddress="noreply@noreply.com"
                                     />
                                 </div>
@@ -90,13 +90,13 @@
                     <div class="forumpostuserattribute forumsig" id="divUntrustedSignature" runat="server" visible='<%# !Convert.ToBoolean(Eval("Trusted")) %>'>
                         <NeatHtml:UntrustedContent ID="UntrustedContent2" runat="server" TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
                             ClientScriptUrl="~/ClientScript/NeatHtml.js">
-                            <%# Eval("PostAuthorSignature").ToString()%>
+                            <%# Server.HtmlEncode(Eval("PostAuthorSignature").ToString())%>
                         </NeatHtml:UntrustedContent>
                     </div>
                     <div class="forumpostuserattribute forumsig" id="divTrustedSignature" runat="server" visible='<%# Convert.ToBoolean(Eval("Trusted")) %>'>
                        <NeatHtml:UntrustedContent ID="UntrustedContent3" runat="server" TrustedImageUrlPattern='<%# allowedImageUrlRegexPattern %>'
                             ClientScriptUrl="~/ClientScript/NeatHtml.js">
-                            <%# Eval("PostAuthorSignature").ToString()%>
+                            <%# Server.HtmlEncode(Eval("PostAuthorSignature").ToString())%>
                         </NeatHtml:UntrustedContent>
                     </div>
                 </div>

--- a/mojoPortal.Features.UI/SharedFiles/SharedFilesModule.ascx.cs
+++ b/mojoPortal.Features.UI/SharedFiles/SharedFilesModule.ascx.cs
@@ -67,54 +67,54 @@ namespace mojoPortal.Web.SharedFilesUI
 		}
 
 
-		private void BindData()
-		{
-			if (CurrentFolderId > -1)
-			{
-				SharedFileFolder folder = new SharedFileFolder(ModuleId, CurrentFolderId);
+        private void BindData()
+        {
+            if (CurrentFolderId > -1)
+            {
+                SharedFileFolder folder = new SharedFileFolder(ModuleId, CurrentFolderId);
 
-				btnGoUp.Visible = true;
-				rptFoldersLinks.Visible = true;
+                btnGoUp.Visible = true;
+                rptFoldersLinks.Visible = true;
 
-				if (displaySettings.ShowClickableFolderPathCrumbs)
-				{
-					lblCurrentDirectory.Visible = false;
+                if (displaySettings.ShowClickableFolderPathCrumbs)
+                {
+                    lblCurrentDirectory.Visible = false;
 
-					// by Thomas N
-					List<SharedFileFolder> allFolders = SharedFileFolder.GetSharedModuleFolderList(folder.ModuleId);
-					rptFoldersLinks.DataSource = SharedFilesHelper.GetAllParentsFolder(folder, allFolders);
+                    // by Thomas N
+                    List<SharedFileFolder> allFolders = SharedFileFolder.GetSharedModuleFolderList(folder.ModuleId);
+                    rptFoldersLinks.DataSource = SharedFilesHelper.GetAllParentsFolder(folder, allFolders);
 
-					IEnumerable<SharedFileFolder> fullPathList = SharedFilesHelper.GetAllParentsFolder(folder, allFolders).Concat(Enumerable.Repeat(folder, 1));
-					rptFoldersLinks.DataSource = fullPathList;
-					rptFoldersLinks.DataBind();
-				}
-				else
-				{
-					lblCurrentDirectory.Text = folder.FolderName;
-				}
-			}
-			else
-			{
-				lblCurrentDirectory.Visible = false;
-				btnGoUp.Visible = false;
-				rptFoldersLinks.Visible = false;
-			}
+                    IEnumerable<SharedFileFolder> fullPathList = SharedFilesHelper.GetAllParentsFolder(folder, allFolders).Concat(Enumerable.Repeat(folder, 1));
+                    rptFoldersLinks.DataSource = fullPathList;
+                    rptFoldersLinks.DataBind();
+                }
+                else
+                {
+                    lblCurrentDirectory.Text = HttpUtility.HtmlEncode(folder.FolderName);
+                }
+            }
+            else
+            {
+                lblCurrentDirectory.Visible = false;
+                btnGoUp.Visible = false;
+                rptFoldersLinks.Visible = false;
+            }
 
-			DataView dv = new DataView(SharedFileFolder.GetFoldersAndFiles(ModuleId, CurrentFolderId));
+            DataView dv = new DataView(SharedFileFolder.GetFoldersAndFiles(ModuleId, CurrentFolderId));
 
-			EnumerableRowCollection<DataRow> query =
-				from row in dv.Table.AsEnumerable()
-				where CheckRoles(row.Field<string>("ViewRoles"))
-				select row;
+            EnumerableRowCollection<DataRow> query =
+                from row in dv.Table.AsEnumerable()
+                where CheckRoles(row.Field<string>("ViewRoles"))
+                select row;
 
-			DataView view = query.AsDataView();
+            DataView view = query.AsDataView();
 
-			view.Sort = $"type ASC, filename {config.DefaultSort}";
-			dgFile.DataSource = view;
-			dgFile.DataBind();
+            view.Sort = $"type ASC, filename {config.DefaultSort}";
+            dgFile.DataSource = view;
+            dgFile.DataBind();
 
-			lblCounter.Text = $"{dgFile.Rows.Count.ToString()} {SharedFileResources.FileManagerObjectsLabel}";
-		}
+            lblCounter.Text = $"{dgFile.Rows.Count.ToString()} {SharedFileResources.FileManagerObjectsLabel}";
+        }
 
 
 		protected bool CheckRoles(string roles)


### PR DESCRIPTION
This PR systematically applies HTML encoding to all user-supplied content before rendering, ensuring that any stored scripts or malicious markup are neutralized. It replaces direct calls to Eval(...).ToString() and unencoded properties like folder names, calendar event fields, and TinyMCE templates with Server.HtmlEncode or HttpUtility.HtmlEncode in both markup and code-behind.

- Stored XSS: The application was previously vulnerable to stored cross-site scripting because user inputs (posts, signatures, folder names, event titles/descriptions, and templates) were injected directly into the page without encoding. We fixed this by wrapping each output with Server.HtmlEncode or HttpUtility.HtmlEncode to escape special characters, preventing the browser from interpreting them as executable code. No additional security configuration changes were required, but please review the encoding calls in case any output needs to remain unencoded (for example, trusted HTML components).

> This Autofix was generated by AI. Please review the change before merging.