### PR TITLE
refactor: validate file paths to prevent path traversal

### DIFF
--- a/Web/Components/FileSystem/DiskFileSystem.cs
+++ b/Web/Components/FileSystem/DiskFileSystem.cs
@@ -189,35 +189,55 @@ namespace mojoPortal.FileSystem
 
 		public bool FileExists(string virtualPath)
 		{
-			return File.Exists(MapPath(virtualPath));
+			string physicalPath = MapPath(virtualPath);
+			string fullPath = Path.GetFullPath(physicalPath);
+			string rootPath = Path.GetFullPath(HostingEnvironment.MapPath("~"));
+			if (!fullPath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+			return File.Exists(fullPath);
 		}
-
-		public bool FolderExists(string virtualPath)
-		{
 			return Directory.Exists(MapPath(virtualPath));
 		}
 
-		public OpResult SaveFile(string virtualPath, Stream stream, string contentType, bool overWrite)
-		{
-			string fullPath = MapPath(virtualPath);
-			if (File.Exists(fullPath))
-			{
-				if (overWrite)
-					File.Delete(fullPath);
-				else
-					return OpResult.AlreadyExist;
-			}
+        public OpResult SaveFile(string virtualPath, Stream stream, string contentType, bool overWrite)
+        {
+            // Sanitize and validate virtual path to prevent path traversal
+            if (virtualPath.Contains(".."))
+            {
+                virtualPath = virtualPath.Replace("..", "");
+            }
 
-			using (stream)
-			{
-				using (Stream file = File.OpenWrite(fullPath))
-				{
-					CopyStream(stream, file);
-				}
-			}
+            string fullPath = MapPath(virtualPath);
 
-			return OpResult.Succeed;
-		}
+            // Ensure the resolved path is within the application root
+            string rootPath = HostingEnvironment.MapPath("~/");
+            string resolvedRootPath = Path.GetFullPath(rootPath);
+            string resolvedFullPath = Path.GetFullPath(fullPath);
+            if (!resolvedFullPath.StartsWith(resolvedRootPath, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new UnauthorizedAccessException("Attempted to access a path outside the application scope.");
+            }
+
+            if (File.Exists(fullPath))
+            {
+                if (overWrite)
+                    File.Delete(fullPath);
+                else
+                    return OpResult.AlreadyExist;
+            }
+
+            using (stream)
+            {
+                using (Stream file = File.OpenWrite(fullPath))
+                {
+                    CopyStream(stream, file);
+                }
+            }
+
+            return OpResult.Succeed;
+        }
 
 		public OpResult SaveFile(string virtualPath, HttpPostedFile file, bool overWrite)
 		{
@@ -312,33 +332,49 @@ namespace mojoPortal.FileSystem
 			{
 				return OpResult.AlreadyExist;
 			}
+        public IEnumerable<WebFile> GetFileList(string virtualPath)
+        {
+            string fullPath = MapPath(virtualPath);
+            
+            // Validate resolved path to prevent path traversal
+            string absolutePath;
+            try
+            {
+                absolutePath = Path.GetFullPath(fullPath);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+            string basePath = HostingEnvironment.MapPath("~/");
+            if (!absolutePath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
 
-			File.Copy(srcPath, destPath, overwrite);
-			return OpResult.Succeed;
-		}
+            if (!Directory.Exists(absolutePath)) { return null; }
+            int fullPathLen = absolutePath.Length + 1;
 
+            var filePaths = Directory.GetFiles(absolutePath);
+            var files = new List<WebFile>(filePaths.Length);
+            foreach (var filePath in filePaths)
+            {
+                FileInfo file = new FileInfo(filePath);
+                files.Add(new WebFile()
+                {
+                    VirtualPath = Path.Combine(virtualPath, file.Name),
+                    Path = file.FullName,
+                    FolderVirtualPath = virtualPath.Substring(0, virtualPath.LastIndexOf('/')),
+                    Name = file.Name,
+                    Size = file.Length,
+                    ContentType = GuessMime(file.Name),
+                    Created = file.CreationTimeUtc,
+                    Modified = file.LastWriteTimeUtc
+                });
 
-		public OpResult DeleteFile(string virtualPath)
-		{
-			string fullPath = MapPath(virtualPath);
-			if (!File.Exists(fullPath))
-				return OpResult.NotFound;
-
-			File.Delete(fullPath);
-			return OpResult.Succeed;
-		}
-
-		public IEnumerable<WebFile> GetFileList(string virtualPath)
-		{
-			string fullPath = MapPath(virtualPath);
-			
-			if (!Directory.Exists(fullPath)) { return null; }
-			int fullPathLen = fullPath.Length + 1;
-
-			var filePaths = Directory.GetFiles(fullPath);
-			var files = new List<WebFile>(filePaths.Length);
-			foreach (var filePath in filePaths)
-			{
+            }
+            return files;
+        }
 				FileInfo file = new FileInfo(filePath);
 				files.Add(new WebFile()
 				{

--- a/Web/Components/SkinConfig.cs
+++ b/Web/Components/SkinConfig.cs
@@ -92,13 +92,26 @@ namespace mojoPortal.Web.Components
 
 		private SkinConfig getSkinConfig(string skinName)
 		{
-			//siteSettings = CacheHelper.GetCurrentSiteSettings();
+			// Validate and sanitize skinName to prevent directory traversal
+			string safeSkinName = Path.GetFileName(skinName);
+			if (string.IsNullOrEmpty(safeSkinName) || safeSkinName != skinName || skinName.IndexOf("..", System.StringComparison.Ordinal) >= 0)
+			{
+				throw new System.ArgumentException("Invalid skin name", nameof(skinName));
+			}
+
 			SkinConfig skinConfig = new();
-			string skinUrlPath = SiteUtils.DetermineSkinBaseUrl(skinName);
+			string skinUrlPath = SiteUtils.DetermineSkinBaseUrl(safeSkinName);
 
-			string configFilePath = HttpContext.Current.Server.MapPath(skinUrlPath + "/config/config.json");
+			string skinDirPath = HttpContext.Current.Server.MapPath(skinUrlPath);
+			string configFilePath = Path.Combine(skinDirPath, "config", "config.json");
+			string fullConfigPath = Path.GetFullPath(configFilePath);
 
-			FileInfo configFile = new(configFilePath);
+			if (!fullConfigPath.StartsWith(Path.GetFullPath(skinDirPath), System.StringComparison.OrdinalIgnoreCase))
+			{
+				throw new System.UnauthorizedAccessException("Invalid skin path");
+			}
+
+			FileInfo configFile = new(fullConfigPath);
 
 			if (configFile.Exists)
 			{

--- a/Web/Controls/ViewSelectorSetting.ascx.cs
+++ b/Web/Controls/ViewSelectorSetting.ascx.cs
@@ -100,7 +100,15 @@ namespace mojoPortal.Web.UI
 
         private List<FileInfo> GetLayouts(string path)
         {
-            DirectoryInfo dir = new(HttpContext.Current.Server.MapPath(path));
+            // Validate the path to prevent path traversal
+            string mappedPath = HttpContext.Current.Server.MapPath(path);
+            string fullPath = Path.GetFullPath(mappedPath);
+            string appRoot = HttpContext.Current.Server.MapPath("~/");
+            if (!fullPath.StartsWith(appRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new UnauthorizedAccessException("Invalid path.");
+            }
+            DirectoryInfo dir = new DirectoryInfo(fullPath);
             List<FileInfo> files = new();
             if (dir.Exists)
             {

--- a/Web/Help.aspx.cs
+++ b/Web/Help.aspx.cs
@@ -2,9 +2,9 @@ using mojoPortal.Business.WebHelpers;
 using mojoPortal.Web.Framework;
 using Resources;
 using System;
+using System.IO;
 using System.Web;
 using System.Web.UI;
-
 namespace mojoPortal.Web.UI.Pages
 {
 	public partial class Help : Page
@@ -19,29 +19,38 @@ namespace mojoPortal.Web.UI.Pages
 		}
 
 
-		protected void Page_Load(object sender, EventArgs e)
-		{
-			if (Request.Params.Get("helpkey") != null)
-			{
-				helpKey = Request.Params.Get("helpkey");
-			}
+        protected void Page_Load(object sender, EventArgs e)
+        {
+            if (Request.Params.Get("helpkey") != null)
+            {
+                helpKey = Request.Params.Get("helpkey");
+                if (!string.IsNullOrEmpty(helpKey))
+                {
+                    // Sanitize helpKey to prevent path traversal
+                    helpKey = Path.GetFileName(helpKey);
+                    foreach (char c in Path.GetInvalidFileNameChars())
+                    {
+                        helpKey = helpKey.Replace(c, '_');
+                    }
+                }
+            }
 
-			if (Request.Params.Get("e") == null)
-			{
-				if (WebUser.IsAdminOrContentAdmin)
-				{
-					if (helpKey != string.Empty)
-					{
-						litEditLink.Text = $"<a href=\"{SiteUtils.GetNavigationSiteRoot()}/HelpEdit.aspx?helpkey={SecurityHelper.RemoveMarkup(helpKey)}\">{Resource.HelpEditLink}</a>";
-					}
-				}
-			}
+            if (Request.Params.Get("e") == null)
+            {
+                if (WebUser.IsAdminOrContentAdmin)
+                {
+                    if (helpKey != string.Empty)
+                    {
+                        litEditLink.Text = $"<a href=\"{SiteUtils.GetNavigationSiteRoot()}/HelpEdit.aspx?helpkey={SecurityHelper.RemoveMarkup(helpKey)}\">{Resource.HelpEditLink}</a>";
+                    }
+                }
+            }
 
-			if (helpKey != string.Empty)
-			{
-				ShowHelp();
-			}
-		}
+            if (helpKey != string.Empty)
+            {
+                ShowHelp();
+            }
+        }
 
 
 		protected void ShowHelp()

--- a/mojoPortal.Features.UI/BetterImageGallery/BetterImageGalleryController.cs
+++ b/mojoPortal.Features.UI/BetterImageGallery/BetterImageGalleryController.cs
@@ -24,8 +24,19 @@ namespace mojoPortal.Features.UI.BetterImageGallery
 		[Route("api/BetterImageGallery/imagehandler")]
 		public IHttpActionResult ImageHandler([FromUri] string path)
 		{
-			var imgPath = HttpContext.Current.Server.MapPath("~/Data/systemfiles/BetterImageGalleryCache/" + path);
-			var fileInfo = new FileInfo(imgPath);
+			// Validate input
+			if (string.IsNullOrWhiteSpace(path) || path.IndexOf("..") >= 0)
+			{
+				return BadRequest("Invalid image path.");
+			}
+			var baseFolder = HttpContext.Current.Server.MapPath("~/Data/systemfiles/BetterImageGalleryCache/");
+			var combinedPath = Path.Combine(baseFolder, path);
+			var fullPath = Path.GetFullPath(combinedPath);
+			if (!fullPath.StartsWith(baseFolder, StringComparison.OrdinalIgnoreCase))
+			{
+				return BadRequest("Invalid image path.");
+			}
+			var fileInfo = new FileInfo(fullPath);
 
 			return !fileInfo.Exists
 				? (IHttpActionResult)NotFound()

--- a/mojoPortal.Features.UI/BetterImageGallery/LayoutSelector.ascx.cs
+++ b/mojoPortal.Features.UI/BetterImageGallery/LayoutSelector.ascx.cs
@@ -92,7 +92,16 @@ namespace mojoPortal.Features.UI.BetterImageGallery
 
 		private List<FileInfo> GetLayouts(string path)
 		{
-			DirectoryInfo dir = new DirectoryInfo(HttpContext.Current.Server.MapPath(path));
+			// Resolve and validate the physical path to prevent directory traversal
+			string mappedPath = HttpContext.Current.Server.MapPath(path);
+			string fullPath = Path.GetFullPath(mappedPath);
+			string rootPath = HttpContext.Current.Server.MapPath("~/");
+			if (!fullPath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
+			{
+				throw new HttpException(403, "Forbidden");
+			}
+
+			DirectoryInfo dir = new DirectoryInfo(fullPath);
 			List<FileInfo> files = new List<FileInfo>();
 
 			if (dir.Exists)

--- a/mojoPortal.Features.UI/Blog/Controls/PostListLayoutSelector.ascx.cs
+++ b/mojoPortal.Features.UI/Blog/Controls/PostListLayoutSelector.ascx.cs
@@ -115,7 +115,16 @@ namespace mojoPortal.Web.BlogUI
         }
         private List<FileInfo> GetLayouts(string path)
         {
-            DirectoryInfo dir = new DirectoryInfo(HttpContext.Current.Server.MapPath(path));
+            // Validate and sanitize path to prevent path traversal
+            string mappedPath = HttpContext.Current.Server.MapPath(path);
+            string fullPath = Path.GetFullPath(mappedPath);
+            string rootPath = HttpContext.Current.Server.MapPath("~/");
+            if (!fullPath.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new UnauthorizedAccessException("Invalid layout path.");
+            }
+
+            DirectoryInfo dir = new DirectoryInfo(fullPath);
             List<FileInfo> files = new List<FileInfo>();
             if (dir.Exists)
             {

--- a/mojoPortal.Web.Framework/ResourceHelper.cs
+++ b/mojoPortal.Web.Framework/ResourceHelper.cs
@@ -183,16 +183,43 @@ namespace mojoPortal.Web.Framework
 
             string path = string.Format("{0}{1}-{2}", folder, curltureInfo.Name, filename);
 
-            if (File.Exists(path))
+            // Validate and get full path to prevent path traversal
+            string baseFolderFull;
+            string fullPath;
+            try
             {
-                return path;
+                baseFolderFull = Path.GetFullPath(folder);
+                fullPath = Path.GetFullPath(path);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+            if (!fullPath.StartsWith(baseFolderFull, StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
             }
 
             // default to file most likely to exist
             path = string.Format("{0}{1}-{2}", folder, "en-US", filename);
-            return path;
-
-            //return File.Exists(path) ? path : GetResourceFilePath(curltureInfo.Parent, folder, filename);
+            try
+            {
+                fullPath = Path.GetFullPath(path);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+            if (!fullPath.StartsWith(baseFolderFull, StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+            return fullPath;
         }
 
         #endregion


### PR DESCRIPTION
This PR refactors file and directory operations to mitigate path traversal vulnerabilities. User-supplied paths are now resolved with Path.GetFullPath and strictly validated against known root directories, and inputs containing “..” segments or invalid filename characters are sanitized or rejected.

- Path Traversal: User-controlled paths could previously include “../” sequences to escape intended directories. We now compute the absolute path, compare it against the application root, image cache base folder, and skin directory (using case-insensitive checks), and throw exceptions or return BadRequest when paths fall outside the allowed scope. Inputs such as helpKey and skinName are also sanitized via Path.GetFileName and by replacing invalid filename characters.

No external security configuration files were modified. The code uses StringComparison.OrdinalIgnoreCase to compare absolute paths for Windows deployments; please review this assumption if you are deploying on case-sensitive file systems and adjust the comparison logic as needed.

> This Autofix was generated by AI. Please review the change before merging.