### PR TITLE
refactor: secure connection string handling

### DIFF
--- a/mojoPortal.Data.SQLite/dbPortal.cs
+++ b/mojoPortal.Data.SQLite/dbPortal.cs
@@ -758,32 +758,39 @@ namespace mojoPortal.Data
             return result;
         }
 
-		public static bool DatabaseHelperUpdateTableField(
-			String connectionString,
-			String tableName, 
-			String keyFieldName,
-			String keyFieldValue,
-			String dataFieldName, 
-			String dataFieldValue,
-			String additionalWhere)
-		{
-			bool result = false;
+        public static bool DatabaseHelperUpdateTableField(
+            String connectionString,
+            String tableName, 
+            String keyFieldName,
+            String keyFieldValue,
+            String dataFieldName, 
+            String dataFieldValue,
+            String additionalWhere)
+        {
+            bool result = false;
 
-			StringBuilder sqlCommand = new StringBuilder();
-			sqlCommand.Append("UPDATE " + tableName + " ");
-			sqlCommand.Append(" SET " + dataFieldName + " = :fieldValue ");
-			sqlCommand.Append(" WHERE " + keyFieldName + " = " + keyFieldValue );
-			sqlCommand.Append(" " + additionalWhere + " ");
-			sqlCommand.Append(" ; ");
-			
-			SqliteParameter[] arParams = new SqliteParameter[1];
+            var csSettings = ConfigurationManager.ConnectionStrings[connectionString];
+            if (csSettings == null)
+            {
+                throw new ArgumentException("Invalid connection string name.", nameof(connectionString));
+            }
+            string safeConnectionString = csSettings.ConnectionString;
 
-			arParams[0] = new SqliteParameter(":fieldValue", DbType.String);
-			arParams[0].Direction = ParameterDirection.Input;
-			arParams[0].Value = dataFieldValue;
+            StringBuilder sqlCommand = new StringBuilder();
+            sqlCommand.Append("UPDATE " + tableName + " ");
+            sqlCommand.Append(" SET " + dataFieldName + " = :fieldValue ");
+            sqlCommand.Append(" WHERE " + keyFieldName + " = " + keyFieldValue );
+            sqlCommand.Append(" " + additionalWhere + " ");
+            sqlCommand.Append(" ; ");
+            
+            SqliteParameter[] arParams = new SqliteParameter[1];
 
-			SqliteConnection connection = new SqliteConnection(connectionString);
-			connection.Open();
+            arParams[0] = new SqliteParameter(":fieldValue", DbType.String);
+            arParams[0].Direction = ParameterDirection.Input;
+            arParams[0].Value = dataFieldValue;
+
+            SqliteConnection connection = new SqliteConnection(safeConnectionString);
+            connection.Open();
             try
             {
                 int rowsAffected = SqliteHelper.ExecuteNonQuery(connection, sqlCommand.ToString(), arParams);
@@ -794,9 +801,9 @@ namespace mojoPortal.Data
                 connection.Close();
             }
 
-			return result;
-			
-		}
+            return result;
+            
+        }
 
         public static bool DatabaseHelperUpdateTableField(
             String tableName,


### PR DESCRIPTION
This PR refactors the DatabaseHelperUpdateTableField method to retrieve the connection string by name from the application configuration instead of accepting a raw connection string directly. It validates the provided connection string name, throws an exception if it’s not found, and uses the safe value for opening the database connection, mitigating connection string injection risks.

- Connection String Injection  
  The original method took an arbitrary connection string and passed it directly into SqliteConnection, which could allow an attacker to inject malicious content. We now require the caller to pass a named entry defined in ConfigurationManager.ConnectionStrings, validate its presence, and only use the trusted, configured connection string value.  

Security Configuration Added:  
• We introduced use of ConfigurationManager.ConnectionStrings to centralize and secure connection string definitions in the application configuration (e.g., app.config or web.config).  
• This configuration ensures that connection strings are stored securely and not in code, reducing exposure.  

Assumptions and Next Steps:  
• We assume that a matching connection string entry exists in the configuration file under the name provided via the connectionString parameter. Please review and add or update the configuration entry for your environment as needed.

> This Autofix was generated by AI. Please review the change before merging.